### PR TITLE
fix: publish immutable catalog generations

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,8 +45,8 @@ store.
 
 **Output:**
 - Updated immutable `snapshot-<snapshot_id>` release assets
-- Updated mutable `catalog-index` assets
-- Updated mutable `history-latest` checkpoint assets when history changed
+- A new immutable `catalog-index-<generation>` release when the index changed
+- A new immutable `history-latest-<generation>` checkpoint release when history changed
 
 ### 3. Release to Hex and NPM (`release.yml`)
 

--- a/README.md
+++ b/README.md
@@ -429,12 +429,27 @@ it appends data. The next run rolls back an interrupted append before it starts.
 The release storage has these growth rules:
 
 - Immutable full snapshot releases grow linearly with changed catalog states.
-- `catalog-index` keeps the two latest complete, versioned index asset pairs.
-- `history-latest` keeps the two latest complete, versioned checkpoint pairs.
-- A publisher uploads a complete new pair before it removes an old pair.
+- Each `catalog-index-<generation>` release contains one complete, versioned
+  index asset pair.
+- Each `history-latest-<generation>` release contains one complete, versioned
+  checkpoint pair.
+- GitHub CLI uploads a generation as a draft and publishes it only after both
+  assets are present. Published generation assets are not changed.
+- The publisher keeps the two latest complete catalog and checkpoint generation
+  releases. It removes older releases only after a replacement is public.
+- Readers use the newest complete generation. They ignore drafts and incomplete
+  releases.
+- Existing fixed `catalog-index` and `history-latest` releases remain readable
+  as migration fallbacks.
 - Legacy immutable `history-*` releases remain readable for migration, but new
   rebuilds do not create more of them.
 - Local history event files grow linearly with recorded model changes.
+
+No one-time data rewrite is required. The first publish with this release
+creates the first generation releases. Current readers can use the old fixed
+releases until those generations exist. Older readers cannot discover later
+generation tags and stay on the last fixed generation, so consumers that fetch
+live catalog updates must upgrade.
 
 This design keeps content-addressed snapshots for audit use. It prevents the
 previous faster-than-linear growth from one new full history release per

--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -78,8 +78,11 @@ $ mix llm_db.snapshot.publish
 $ mix llm_db.history.rebuild --publish
 ```
 
-This publishes immutable snapshot releases plus the mutable `catalog-index`
-assets: `latest.json`, `snapshot-index.json`, `history.tar.gz`, and `history-meta.json`.
+This publishes immutable snapshot releases and complete immutable generations.
+`catalog-index-<generation>` contains versioned forms of `latest.json` and
+`snapshot-index.json`. `history-latest-<generation>` contains versioned forms
+of `history.tar.gz` and `history-meta.json`. The publisher keeps the two latest
+complete releases for each type.
 
 ## Versioning and Tagging
 

--- a/lib/llm_db/snapshot/release_store.ex
+++ b/lib/llm_db/snapshot/release_store.ex
@@ -3,10 +3,11 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   GitHub Releases-backed snapshot artifact store.
 
   Runtime fetching resolves immutable snapshots through the latest complete
-  catalog asset generation. It resolves history through the latest complete
-  checkpoint generation. A release scan supports migration when these assets
-  do not exist. Publishing uses versioned asset pairs and keeps two complete
-  generations. It uses the `gh` CLI for maintainer workflows and GitHub Actions.
+  catalog generation release. It resolves history through the latest complete
+  checkpoint generation release. Fixed-tag assets and a release scan support
+  migration when these releases do not exist. Publishing creates one immutable
+  release for each complete asset pair. It uses the `gh` CLI for maintainer
+  workflows and GitHub Actions.
 
   This shared transport is internal. Runtime consumers configure snapshot
   sources through `LLMDB.load/1`; maintainers use the supported
@@ -22,6 +23,7 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   @default_cache_dir Path.join(["tmp", "llm_db", "snapshot_cache"])
   @github_api_version "2022-11-28"
   @release_page_size 100
+  @generation_publish_attempts 2
   @retained_generations 2
 
   @catalog_asset_specs %{
@@ -155,8 +157,31 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   end
 
   defp latest_release_assets(repo, tag, asset_specs, overrides) do
-    with {:ok, release} <- release_by_tag(repo, tag, overrides) do
-      complete_release_assets(release, asset_specs)
+    case latest_generation_release_assets(repo, tag, asset_specs, overrides) do
+      {:ok, _assets} = result ->
+        result
+
+      {:error, :not_found} ->
+        with {:ok, release} <- release_by_tag(repo, tag, overrides) do
+          complete_release_assets(release, asset_specs)
+        end
+
+      error ->
+        error
+    end
+  end
+
+  defp latest_generation_release_assets(repo, base_tag, asset_specs, overrides) do
+    with {:ok, releases} <- recent_releases(repo, overrides) do
+      releases
+      |> Enum.filter(&generation_release?(&1, base_tag))
+      |> Enum.sort_by(&release_identity/1, :desc)
+      |> Enum.find_value({:error, :not_found}, fn release ->
+        case complete_release_assets(release, asset_specs) do
+          {:ok, _assets} = result -> result
+          {:error, :not_found} -> nil
+        end
+      end)
     end
   end
 
@@ -610,25 +635,6 @@ defmodule LLMDB.Snapshot.ReleaseStore do
     end)
   end
 
-  defp complete_generations(asset_names, asset_specs) do
-    asset_specs
-    |> Map.values()
-    |> Enum.map(fn {prefix, suffix} ->
-      asset_names
-      |> Enum.map(&versioned_generation(&1, prefix, suffix))
-      |> Enum.reject(&is_nil/1)
-      |> MapSet.new()
-    end)
-    |> intersect_sets()
-    |> MapSet.to_list()
-  end
-
-  defp asset_generation(name, asset_specs) do
-    Enum.find_value(asset_specs, fn {_key, {prefix, suffix}} ->
-      versioned_generation(name, prefix, suffix)
-    end)
-  end
-
   defp versioned_generation(name, prefix, suffix) when is_binary(name) do
     if String.starts_with?(name, prefix) and String.ends_with?(name, suffix) do
       generation_size = byte_size(name) - byte_size(prefix) - byte_size(suffix)
@@ -646,6 +652,7 @@ defmodule LLMDB.Snapshot.ReleaseStore do
 
   defp release_tag_name(%{"tag_name" => tag}), do: tag
   defp release_tag_name(%{tag_name: tag}), do: tag
+  defp release_tag_name(_release), do: nil
 
   defp release_published_at(%{"published_at" => published_at}), do: published_at
   defp release_published_at(%{published_at: published_at}), do: published_at
@@ -712,6 +719,8 @@ defmodule LLMDB.Snapshot.ReleaseStore do
   end
 
   defp create_release(tag, repo, title, asset_paths) do
+    # `gh release create` uses a draft while it uploads the supplied assets. It
+    # publishes the release only after all uploads succeed.
     args =
       ["release", "create", tag]
       |> Kernel.++(asset_paths)
@@ -723,7 +732,27 @@ defmodule LLMDB.Snapshot.ReleaseStore do
     end
   end
 
-  defp publish_versioned_release(tag, repo, title, generation, asset_specs, sources) do
+  defp publish_versioned_release(base_tag, repo, title, generation, asset_specs, sources) do
+    do_publish_versioned_release(
+      base_tag,
+      repo,
+      title,
+      generation,
+      asset_specs,
+      sources,
+      @generation_publish_attempts
+    )
+  end
+
+  defp do_publish_versioned_release(
+         base_tag,
+         repo,
+         title,
+         generation,
+         asset_specs,
+         sources,
+         attempts_left
+       ) do
     staging_dir =
       Path.join(
         System.tmp_dir!(),
@@ -740,78 +769,77 @@ defmodule LLMDB.Snapshot.ReleaseStore do
       end)
 
     try do
-      with :ok <- ensure_mutable_release(tag, repo, title),
-           :ok <- upload_release_assets(tag, repo, Map.values(staged_paths)),
-           :ok <- prune_release_assets(tag, repo, asset_specs, generation) do
-        {:ok, tag}
+      tag = "#{base_tag}-#{generation}"
+
+      case create_release(tag, repo, title, Map.values(staged_paths)) do
+        {:ok, ^tag} ->
+          with :ok <- prune_generation_releases(base_tag, repo, tag) do
+            {:ok, tag}
+          end
+
+        {:error, reason} when attempts_left > 1 ->
+          if immutable_release_error?(reason) do
+            replacement_generation = "#{generation}-#{generation_id()}"
+
+            do_publish_versioned_release(
+              base_tag,
+              repo,
+              title,
+              replacement_generation,
+              asset_specs,
+              sources,
+              attempts_left - 1
+            )
+          else
+            {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
       end
     after
       File.rm_rf!(staging_dir)
     end
   end
 
-  defp ensure_mutable_release(tag, repo, title) do
-    case run_gh(["release", "view", tag, "--repo", repo]) do
-      {:ok, _output} ->
-        :ok
-
-      {:error, _reason} ->
-        case create_release(tag, repo, title, []) do
-          {:ok, ^tag} -> :ok
-          {:error, reason} -> {:error, reason}
-        end
-    end
+  defp immutable_release_error?(reason) when is_binary(reason) do
+    String.contains?(reason, "HTTP 422") and
+      String.contains?(String.downcase(reason), "immutable release")
   end
 
-  defp upload_release_assets(tag, repo, asset_paths) do
-    args = ["release", "upload", tag] ++ asset_paths ++ ["--repo", repo]
+  defp prune_generation_releases(base_tag, repo, published_tag) do
+    args = [
+      "release",
+      "list",
+      "--repo",
+      repo,
+      "--limit",
+      Integer.to_string(@release_page_size),
+      "--json",
+      "tagName,isDraft,publishedAt"
+    ]
 
-    case run_gh(args) do
-      {:ok, _output} -> :ok
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp prune_release_assets(tag, repo, asset_specs, published_generation) do
-    with {:ok, asset_names} <- release_asset_names(tag, repo) do
-      retained_generations =
-        asset_names
-        |> complete_generations(asset_specs)
-        |> Enum.sort(:desc)
-        |> Enum.take(@retained_generations)
-        |> MapSet.new()
-
-      asset_names
-      |> Enum.filter(fn name ->
-        case asset_generation(name, asset_specs) do
-          nil ->
-            false
-
-          generation ->
-            generation < published_generation and
-              not MapSet.member?(retained_generations, generation)
-        end
+    with {:ok, output} <- run_gh(args),
+         {:ok, releases} when is_list(releases) <- Jason.decode(output) do
+      releases
+      |> Enum.reject(& &1["isDraft"])
+      |> Enum.filter(fn release ->
+        tag = release["tagName"]
+        is_binary(tag) and tag != published_tag and String.starts_with?(tag, "#{base_tag}-")
       end)
-      |> Enum.reduce_while(:ok, fn name, :ok ->
-        case run_gh(["release", "delete-asset", tag, name, "--repo", repo, "--yes"]) do
+      |> Enum.sort_by(&{&1["publishedAt"] || "", &1["tagName"]}, :desc)
+      |> Enum.drop(@retained_generations - 1)
+      |> Enum.reduce_while(:ok, fn release, :ok ->
+        tag = release["tagName"]
+
+        case run_gh(["release", "delete", tag, "--repo", repo, "--yes", "--cleanup-tag"]) do
           {:ok, _output} -> {:cont, :ok}
           {:error, reason} -> {:halt, {:error, reason}}
         end
       end)
-    end
-  end
-
-  defp release_asset_names(tag, repo) do
-    case run_gh(["release", "view", tag, "--repo", repo, "--json", "assets"]) do
-      {:ok, output} ->
-        with {:ok, %{"assets" => assets}} when is_list(assets) <- Jason.decode(output) do
-          {:ok, Enum.map(assets, & &1["name"])}
-        else
-          _error -> {:error, :invalid_release_assets}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
+    else
+      {:ok, _other} -> {:error, :invalid_release_list}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -819,10 +847,35 @@ defmodule LLMDB.Snapshot.ReleaseStore do
     do_list_releases(repo, overrides, 1, [])
   end
 
+  defp recent_releases(repo, overrides) do
+    url = "https://api.github.com/repos/#{repo}/releases"
+
+    case api_get_json(url, [params: [per_page: @release_page_size, page: 1]], overrides) do
+      {:ok, releases} when is_list(releases) -> {:ok, releases}
+      {:ok, other} -> {:error, {:invalid_release_list, other}}
+      error -> error
+    end
+  end
+
   defp release_by_tag(repo, tag, overrides) do
     encoded_tag = URI.encode_www_form(tag)
     url = "https://api.github.com/repos/#{repo}/releases/tags/#{encoded_tag}"
     api_get_json(url, [], overrides)
+  end
+
+  defp generation_release?(release, base_tag) do
+    tag = release_tag_name(release)
+    draft? = Map.get(release, "draft", Map.get(release, :draft, false))
+
+    draft? != true and is_binary(tag) and String.starts_with?(tag, "#{base_tag}-")
+  end
+
+  defp release_identity(release) do
+    {
+      release_published_at(release) || "",
+      Map.get(release, "created_at", Map.get(release, :created_at, "")),
+      release_tag_name(release) || ""
+    }
   end
 
   defp do_list_releases(repo, overrides, page, acc) do

--- a/lib/mix/tasks/llm_db.history.migrate_git.ex
+++ b/lib/mix/tasks/llm_db.history.migrate_git.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.LlmDb.History.MigrateGit do
 
   By default this writes local artifacts only. With `--publish`, it also seeds
   GitHub Releases with all discovered immutable snapshots and uploads a rebuilt
-  compact catalog index and the mutable latest history bundle.
+  compact catalog index and latest history bundle as immutable generations.
   """
 
   @impl Mix.Task

--- a/lib/mix/tasks/llm_db.history.rebuild.ex
+++ b/lib/mix/tasks/llm_db.history.rebuild.ex
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.LlmDb.History.Rebuild do
   @moduledoc """
   Rebuilds local history artifacts from the published snapshot observation chain,
   then bundles the result and optionally publishes `history.tar.gz` plus
-  `history-meta.json` to the mutable `history-latest` release.
+  `history-meta.json` to one immutable `history-latest-<generation>` release.
 
   By default, the task installs the latest published checkpoint and processes
   only new snapshots. Use `--full` for an audit or repair rebuild.

--- a/lib/mix/tasks/llm_db.snapshot.publish.ex
+++ b/lib/mix/tasks/llm_db.snapshot.publish.ex
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.LlmDb.Snapshot.Publish do
 
   This creates or repairs the immutable snapshot release for the current
   `snapshot_id`. It also publishes `latest.json` and `snapshot-index.json` to
-  the mutable compact catalog-index release.
+  one immutable `catalog-index-<generation>` release.
   """
 
   @impl Mix.Task

--- a/test/llm_db/snapshot/release_store_test.exs
+++ b/test/llm_db/snapshot/release_store_test.exs
@@ -3,7 +3,7 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
 
   alias LLMDB.Snapshot.ReleaseStore
 
-  test "creates snapshot and history releases atomically with unique tags" do
+  test "creates snapshot, catalog, and history releases atomically with unique tags" do
     tmp_dir = tmp_dir("release_store_create")
     bin_dir = Path.join(tmp_dir, "bin")
     assets_dir = Path.join(tmp_dir, "assets")
@@ -13,6 +13,8 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
 
     {snapshot_path, snapshot_meta_path, history_archive_path, history_meta_path} =
       write_assets!(assets_dir)
+
+    {snapshot_index_path, latest_path} = write_catalog_assets!(assets_dir)
 
     File.mkdir_p!(bin_dir)
     File.write!(script_path, gh_script(log_path))
@@ -34,6 +36,11 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
 
     assert snapshot_tag =~ ~r/^snapshot-abc-\d+-\d+$/
 
+    assert {:ok, catalog_tag} =
+             ReleaseStore.publish_snapshot_index([snapshot_index_path, latest_path])
+
+    assert catalog_tag =~ ~r/^catalog-index-\d+-\d+$/
+
     assert {:ok, history_tag} =
              ReleaseStore.publish_history_release(
                [history_archive_path, history_meta_path],
@@ -41,19 +48,22 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
                history_entries: []
              )
 
-    assert history_tag == "history-latest"
+    assert history_tag =~ ~r/^history-latest-\d+-\d+-abc$/
 
     log = File.read!(log_path)
     assert log =~ "release create #{snapshot_tag} #{snapshot_path} #{snapshot_meta_path}"
-    assert log =~ "release view history-latest"
-    assert log =~ "release create history-latest --repo agentjido/llmdb"
-    assert log =~ "release upload history-latest"
+    assert log =~ "release create #{catalog_tag}"
+    assert log =~ "snapshot-index-"
+    assert log =~ "latest-"
+    assert log =~ "release create #{history_tag}"
     assert log =~ "history-meta-"
     assert log =~ ".tar.gz"
+    refute log =~ "release upload"
+    refute log =~ "delete-asset"
     refute log =~ "--clobber"
   end
 
-  test "reuses already indexed snapshot and history releases" do
+  test "reuses an indexed snapshot and publishes a new history generation" do
     tmp_dir = tmp_dir("release_store_reuse")
     bin_dir = Path.join(tmp_dir, "bin")
     assets_dir = Path.join(tmp_dir, "assets")
@@ -96,18 +106,21 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
                snapshot_index: [existing_snapshot_entry]
              )
 
-    assert {:ok, "history-latest"} =
+    assert {:ok, history_tag} =
              ReleaseStore.publish_history_release(
                [history_archive_path, history_meta_path],
                "abc",
                history_entries: [existing_history_entry]
              )
 
+    assert history_tag =~ ~r/^history-latest-\d+-\d+-abc$/
+
     log = File.read!(log_path)
-    assert log =~ "release view history-latest"
-    assert log =~ "release upload history-latest"
+    assert log =~ "release create #{history_tag}"
+    assert log =~ "history-meta-"
+    assert log =~ ".tar.gz"
     refute log =~ "--clobber"
-    refute log =~ "release create"
+    refute log =~ "release upload"
   end
 
   test "creates a fresh unique snapshot release when only broken historical tags exist" do
@@ -162,6 +175,9 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
       send(test_pid, {:request, conn.request_path})
 
       case conn.request_path do
+        "/repos/agentjido/llmdb/releases" ->
+          Req.Test.json(conn, [])
+
         "/repos/agentjido/llmdb/releases/tags/catalog-index" ->
           Req.Test.json(conn, versioned_release("catalog-index", "0001"))
 
@@ -179,6 +195,7 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     assert length(loaded) == 1_001
     assert List.last(loaded)["snapshot_id"] == "snapshot-1001"
 
+    assert_receive {:request, "/repos/agentjido/llmdb/releases"}
     assert_receive {:request, "/repos/agentjido/llmdb/releases/tags/catalog-index"}
     assert_receive {:request, "/catalog/snapshot-index-0001.json"}
 
@@ -194,8 +211,8 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
       send(test_pid, {:request, conn.request_path})
 
       case conn.request_path do
-        "/repos/agentjido/llmdb/releases/tags/catalog-index" ->
-          Req.Test.json(conn, versioned_release("catalog-index", "0001"))
+        "/repos/agentjido/llmdb/releases" ->
+          Req.Test.json(conn, [versioned_release("catalog-index-0001", "0001")])
 
         "/catalog/snapshot-index-0001.json" ->
           conn
@@ -225,35 +242,42 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     assert {:ok, %{snapshot_id: ^snapshot_id}} =
              ReleaseStore.fetch_snapshot(:latest, cache_dir: cache_dir, req_opts: [plug: plug])
 
-    assert_receive {:request, "/repos/agentjido/llmdb/releases/tags/catalog-index"}
+    assert_receive {:request, "/repos/agentjido/llmdb/releases"}
     assert_receive {:request, "/catalog/snapshot-index-0001.json"}
 
     assert_receive {:request, "/snapshot.json"}
     refute_receive {:request, _path}
   end
 
-  test "ignores a newer incomplete catalog asset generation" do
+  test "selects the latest complete catalog generation release" do
     test_pid = self()
 
     plug = fn conn ->
       send(test_pid, {:request, conn.request_path})
 
       case conn.request_path do
-        "/repos/agentjido/llmdb/releases/tags/catalog-index" ->
-          release =
-            versioned_release("catalog-index", "0001")
-            |> update_in(["assets"], fn assets ->
-              [
-                %{
-                  "name" => "snapshot-index-0002.json",
-                  "browser_download_url" =>
-                    "https://example.test/catalog/snapshot-index-0002.json"
-                }
-                | assets
-              ]
-            end)
+        "/repos/agentjido/llmdb/releases" ->
+          draft_release =
+            versioned_release("catalog-index-0003", "0003")
+            |> Map.put("published_at", "2026-08-24T03:00:00Z")
+            |> Map.put("draft", true)
 
-          Req.Test.json(conn, release)
+          incomplete_release = %{
+            "tag_name" => "catalog-index-0002",
+            "published_at" => "2026-08-24T02:00:00Z",
+            "assets" => [
+              %{
+                "name" => "snapshot-index-0002.json",
+                "browser_download_url" => "https://example.test/catalog/snapshot-index-0002.json"
+              }
+            ]
+          }
+
+          complete_release =
+            versioned_release("catalog-index-0001", "0001")
+            |> Map.put("published_at", "2026-08-24T01:00:00Z")
+
+          Req.Test.json(conn, [draft_release, incomplete_release, complete_release])
 
         "/catalog/snapshot-index-0001.json" ->
           Req.Test.json(conn, %{"schema_version" => 1, "snapshots" => []})
@@ -261,11 +285,63 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     end
 
     assert {:ok, []} = ReleaseStore.fetch_snapshot_index(req_opts: [plug: plug])
+    assert_receive {:request, "/repos/agentjido/llmdb/releases"}
     assert_receive {:request, "/catalog/snapshot-index-0001.json"}
     refute_receive {:request, "/catalog/snapshot-index-0002.json"}
+    refute_receive {:request, "/catalog/snapshot-index-0003.json"}
   end
 
-  test "keeps existing release assets when a replacement upload fails" do
+  test "fetches history from the latest immutable checkpoint generation" do
+    test_pid = self()
+
+    plug = fn conn ->
+      send(test_pid, {:request, conn.request_path})
+
+      case conn.request_path do
+        "/repos/agentjido/llmdb/releases" ->
+          Req.Test.json(conn, [history_versioned_release("history-latest-0001", "0001")])
+
+        "/history/history-meta-0001.json" ->
+          Req.Test.json(conn, %{"to_snapshot_id" => "abc"})
+      end
+    end
+
+    assert {:ok, %{"to_snapshot_id" => "abc"}} =
+             ReleaseStore.fetch_history_meta(req_opts: [plug: plug])
+
+    assert_receive {:request, "/repos/agentjido/llmdb/releases"}
+    assert_receive {:request, "/history/history-meta-0001.json"}
+    refute_receive {:request, _path}
+  end
+
+  test "keeps the fixed history checkpoint release readable during migration" do
+    test_pid = self()
+
+    plug = fn conn ->
+      send(test_pid, {:request, conn.request_path})
+
+      case conn.request_path do
+        "/repos/agentjido/llmdb/releases" ->
+          Req.Test.json(conn, [])
+
+        "/repos/agentjido/llmdb/releases/tags/history-latest" ->
+          Req.Test.json(conn, history_versioned_release("history-latest", "0001"))
+
+        "/history/history-meta-0001.json" ->
+          Req.Test.json(conn, %{"to_snapshot_id" => "legacy"})
+      end
+    end
+
+    assert {:ok, %{"to_snapshot_id" => "legacy"}} =
+             ReleaseStore.fetch_history_meta(req_opts: [plug: plug])
+
+    assert_receive {:request, "/repos/agentjido/llmdb/releases"}
+    assert_receive {:request, "/repos/agentjido/llmdb/releases/tags/history-latest"}
+    assert_receive {:request, "/history/history-meta-0001.json"}
+    refute_receive {:request, _path}
+  end
+
+  test "returns the GitHub error without changing an earlier generation" do
     tmp_dir = tmp_dir("release_store_upload_failure")
     bin_dir = Path.join(tmp_dir, "bin")
     assets_dir = Path.join(tmp_dir, "assets")
@@ -277,26 +353,62 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
       write_assets!(assets_dir)
 
     File.mkdir_p!(bin_dir)
-    File.write!(script_path, gh_script(log_path, "history-latest", fail_upload: true))
+    File.write!(script_path, gh_script(log_path, nil, fail_create: true))
     File.chmod!(script_path, 0o755)
     File.write!(log_path, "")
     System.put_env("PATH", "#{bin_dir}:#{original_path}")
 
     on_exit(fn -> System.put_env("PATH", original_path) end)
 
-    assert {:error, "upload failed"} =
+    assert {:error, "create failed"} =
              ReleaseStore.publish_history_release(
                [history_archive_path, history_meta_path],
                "abc"
              )
 
     log = File.read!(log_path)
-    assert log =~ "release upload history-latest"
+    assert log =~ "release create history-latest-"
     refute log =~ "--clobber"
+    refute log =~ "release upload"
     refute log =~ "delete-asset"
   end
 
-  test "retains the two latest complete release asset generations" do
+  test "retries with a replacement generation after GitHub returns immutable release 422" do
+    tmp_dir = tmp_dir("release_store_retention")
+    bin_dir = Path.join(tmp_dir, "bin")
+    assets_dir = Path.join(tmp_dir, "assets")
+    log_path = Path.join(tmp_dir, "gh.log")
+    script_path = Path.join(bin_dir, "gh")
+    original_path = System.get_env("PATH")
+
+    {snapshot_index_path, latest_path} = write_catalog_assets!(assets_dir)
+
+    File.mkdir_p!(bin_dir)
+    File.write!(script_path, gh_script(log_path, nil, immutable_create_once: true))
+    File.chmod!(script_path, 0o755)
+    File.write!(log_path, "")
+    System.put_env("PATH", "#{bin_dir}:#{original_path}")
+
+    on_exit(fn -> System.put_env("PATH", original_path) end)
+
+    assert {:ok, replacement_tag} =
+             ReleaseStore.publish_snapshot_index([snapshot_index_path, latest_path])
+
+    create_commands =
+      log_path
+      |> File.read!()
+      |> String.split("\n", trim: true)
+      |> Enum.filter(&String.starts_with?(&1, "release create catalog-index-"))
+
+    assert length(create_commands) == 2
+    [failed_command, replacement_command] = create_commands
+    refute failed_command == replacement_command
+    assert replacement_command =~ "release create #{replacement_tag}"
+    refute replacement_command =~ "release upload catalog-index"
+    refute replacement_command =~ "delete-asset"
+  end
+
+  test "retains two complete immutable generation releases" do
     tmp_dir = tmp_dir("release_store_retention")
     bin_dir = Path.join(tmp_dir, "bin")
     assets_dir = Path.join(tmp_dir, "assets")
@@ -307,36 +419,27 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     {_snapshot_path, _snapshot_meta_path, history_archive_path, history_meta_path} =
       write_assets!(assets_dir)
 
-    old_assets =
-      for generation <- ["0001", "0002", "0003"],
-          name <- ["history-#{generation}.tar.gz", "history-meta-#{generation}.json"] do
-        name
-      end
+    release_tags = ["history-latest-0002", "history-latest-0001"]
 
     File.mkdir_p!(bin_dir)
-
-    File.write!(
-      script_path,
-      gh_script(log_path, "history-latest", release_assets: old_assets)
-    )
-
+    File.write!(script_path, gh_script(log_path, nil, release_tags: release_tags))
     File.chmod!(script_path, 0o755)
     File.write!(log_path, "")
     System.put_env("PATH", "#{bin_dir}:#{original_path}")
 
     on_exit(fn -> System.put_env("PATH", original_path) end)
 
-    assert {:ok, "history-latest"} =
+    assert {:ok, history_tag} =
              ReleaseStore.publish_history_release(
                [history_archive_path, history_meta_path],
                "abc"
              )
 
     log = File.read!(log_path)
-    assert log =~ "delete-asset history-latest history-0001.tar.gz"
-    assert log =~ "delete-asset history-latest history-meta-0001.json"
-    refute log =~ "delete-asset history-latest history-0002"
-    refute log =~ "delete-asset history-latest history-0003"
+    assert log =~ "release create #{history_tag}"
+    assert log =~ "release delete history-latest-0001"
+    refute log =~ "release delete history-latest-0002"
+    refute log =~ "delete-asset"
   end
 
   defp write_assets!(assets_dir) do
@@ -355,43 +458,63 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
     {snapshot_path, snapshot_meta_path, history_archive_path, history_meta_path}
   end
 
-  defp gh_script(log_path, existing_tag \\ nil, opts \\ []) do
-    fail_upload? = Keyword.get(opts, :fail_upload, false)
+  defp write_catalog_assets!(assets_dir) do
+    File.mkdir_p!(assets_dir)
 
-    release_assets =
+    snapshot_index_path = Path.join(assets_dir, "snapshot-index.json")
+    latest_path = Path.join(assets_dir, "latest.json")
+
+    File.write!(snapshot_index_path, ~s({"schema_version":1,"snapshots":[]}))
+    File.write!(latest_path, ~s({"snapshot_id":"abc"}))
+
+    {snapshot_index_path, latest_path}
+  end
+
+  defp gh_script(log_path, existing_tag \\ nil, opts \\ []) do
+    fail_create? = Keyword.get(opts, :fail_create, false)
+    immutable_create_once? = Keyword.get(opts, :immutable_create_once, false)
+    immutable_marker = "#{log_path}.immutable-release"
+
+    release_list =
       opts
-      |> Keyword.get(:release_assets, [])
-      |> Enum.map(&%{"name" => &1})
-      |> then(&Jason.encode!(%{"assets" => &1}))
+      |> Keyword.get(:release_tags, [])
+      |> Enum.map(&%{"tagName" => &1, "isDraft" => false})
+      |> Jason.encode!()
 
     """
     #!/bin/sh
     set -eu
     printf '%s\\n' "$*" >> "#{log_path}"
 
-    if [ "$1" = "release" ] && [ "$2" = "view" ] && [ "${7:-}" = "assets" ]; then
-      printf '%s\\n' '#{release_assets}'
-      exit 0
-    fi
-
     if [ "$1" = "release" ] && [ "$2" = "view" ] && [ "$3" = "#{existing_tag}" ]; then
       exit 0
     fi
 
+    if [ "$1" = "release" ] && [ "$2" = "list" ]; then
+      printf '%s\\n' '#{release_list}'
+      exit 0
+    fi
+
     if [ "$1" = "release" ] && [ "$2" = "create" ]; then
+      if [ "#{immutable_create_once?}" = "true" ] && [ ! -e "#{immutable_marker}" ]; then
+        : > "#{immutable_marker}"
+        echo "HTTP 422: Cannot upload assets to an immutable release." >&2
+        exit 1
+      fi
+      if [ "#{fail_create?}" = "true" ]; then
+        echo "create failed" >&2
+        exit 1
+      fi
       echo "https://github.com/agentjido/llmdb/releases/tag/$3"
       exit 0
     fi
 
     if [ "$1" = "release" ] && [ "$2" = "upload" ]; then
-      if [ "#{fail_upload?}" = "true" ]; then
-        echo "upload failed" >&2
-        exit 1
-      fi
-      exit 0
+      echo "HTTP 422: Cannot upload assets to an immutable release." >&2
+      exit 1
     fi
 
-    if [ "$1" = "release" ] && [ "$2" = "delete-asset" ]; then
+    if [ "$1" = "release" ] && [ "$2" = "delete" ]; then
       exit 0
     fi
 
@@ -412,6 +535,22 @@ defmodule LLMDB.Snapshot.ReleaseStoreTest do
         %{
           "name" => "latest-#{generation}.json",
           "browser_download_url" => "https://example.test/catalog/latest-#{generation}.json"
+        }
+      ]
+    }
+  end
+
+  defp history_versioned_release(tag, generation) do
+    %{
+      "tag_name" => tag,
+      "assets" => [
+        %{
+          "name" => "history-#{generation}.tar.gz",
+          "browser_download_url" => "https://example.test/history/history-#{generation}.tar.gz"
+        },
+        %{
+          "name" => "history-meta-#{generation}.json",
+          "browser_download_url" => "https://example.test/history/history-meta-#{generation}.json"
         }
       ]
     }


### PR DESCRIPTION
## Description

- publish each catalog index and history checkpoint as a new immutable generation release
- pass each complete asset pair to one `gh release create` operation so GitHub publishes it only after both uploads succeed
- retry the exact GitHub 422 immutable-release failure with a new generation ID
- select the newest complete published generation while ignoring drafts and incomplete releases
- keep the fixed `catalog-index`, fixed `history-latest`, and legacy release-scan read paths for compatibility and recovery
- retain two complete generations by removing older releases only after the replacement is public
- update maintainer and workflow documentation for the immutable model

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

None for current readers. No one-time data rewrite is required. The first publish after this change creates the first `catalog-index-<generation>` and `history-latest-<generation>` releases. Existing fixed-tag releases and legacy immutable snapshot and history releases remain readable.

Clients from before this change cannot discover future generation tags. They stay on the last fixed generation and must upgrade to continue to receive live catalog updates.

## Testing

- [x] Focused release-store tests: `mix test test/llm_db/snapshot/release_store_test.exs` — 11 passed
- [x] Full test suite: `mix test` — 916 passed (41 doctests and 875 tests)
- [x] Quality checks: `mix quality` — formatting, warnings-as-errors compilation, Credo, and Dialyzer passed
- [x] Pre-push hooks repeated the full test suite and quality checks successfully
- [x] Live compatibility smoke read loaded the existing fixed catalog index with 135 entries

Focused coverage includes the exact GitHub 422 immutable-release response, replacement generation retry, atomic create commands, draft and incomplete generation rejection, fixed-tag migration reads, history checkpoint discovery, and two-generation retention.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
- [x] I have **NOT** directly edited generated snapshot/history artifacts unless this PR intentionally regenerates them (`priv/llm_db/snapshot.json`, `priv/llm_db/history/**`)

## Related Issues

Closes #311
